### PR TITLE
feat: add missing view methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # aurora-workspace
+
 Aurora EVM contract for the Near workspaces library
 
 ## Minimum Supported Rust Version (MSRV)

--- a/res/mock_evm/Cargo.toml
+++ b/res/mock_evm/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aurora-workspace-types = { path = "../../workspace-types", features = ["mock"] }
+hex = "0.4.3"
 near-sdk = "4.0"
 serde = { version = "1", features = ["derive"] }
 

--- a/res/mock_evm/src/ft.rs
+++ b/res/mock_evm/src/ft.rs
@@ -1,11 +1,12 @@
 use crate::*;
+use near_sdk::json_types::U128;
 use near_sdk::serde_json;
 
 #[near_bindgen]
 impl MockEvmContract {
-    pub fn ft_transfer(&mut self, receiver_id: String, amount: u128, memo: Option<String>) {
+    pub fn ft_transfer(&mut self, receiver_id: String, amount: U128, memo: Option<String>) {
         assert_eq!(receiver_id, "some_account.test");
-        assert_eq!(amount, 10);
+        assert_eq!(amount.0, 10);
         assert_eq!(memo, Some("some message".to_string()));
     }
 

--- a/res/mock_evm/src/lib.rs
+++ b/res/mock_evm/src/lib.rs
@@ -1,14 +1,14 @@
+use crate::out::SubmitResult;
 use aurora_workspace_types::input::{CallInput, DeployErc20Input, SetEthConnectorInput};
 use aurora_workspace_types::output::{Log, TransactionStatus};
-use aurora_workspace_types::{AccountId, Address, H256, Raw};
+use aurora_workspace_types::{AccountId, Address, Raw, H256};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::{near_bindgen, PanicOnDefault};
-use crate::out::SubmitResult;
 
-mod metadata;
-mod storage;
-mod out;
 pub mod ft;
+mod metadata;
+mod out;
+mod storage;
 
 fn dummy_submit_result() -> SubmitResult {
     let log = Log::new(

--- a/res/mock_evm/src/metadata.rs
+++ b/res/mock_evm/src/metadata.rs
@@ -1,0 +1,48 @@
+use std::ascii;
+
+use aurora_workspace_types::{output::TransactionStatus, AccountId, Raw};
+use near_sdk::{borsh, near_bindgen};
+
+use crate::{MockEvmContract, MockEvmContractExt};
+
+#[near_bindgen]
+impl MockEvmContract {
+    pub fn get_version(&self) -> String {
+        "v1".to_string()
+    }
+
+    pub fn ft_total_eth_supply_on_aurora(&self) -> String {
+        "0".into()
+    }
+
+    #[result_serializer(borsh)]
+    pub fn get_view(&self, #[serializer(borsh)] _input: Raw) -> TransactionStatus {
+        TransactionStatus::Succeed(vec![])
+    }
+
+    #[result_serializer(borsh)]
+    pub fn get_code(&self, #[serializer(borsh)] _input: Raw) -> Raw {
+        // `(string,bool,string) (spiral,true,quasar)`
+        Raw(hex::decode(b"00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000673706972616c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000067175617361720000000000000000000000000000000000000000000000000000").unwrap())
+    }
+
+    #[result_serializer(borsh)]
+    pub fn get_storage_at(&self, #[serializer(borsh)] _input: Raw) -> [u8; 32] {
+        [1; 32]
+    }
+
+    #[result_serializer(borsh)]
+    pub fn get_erc20_from_nep141(&self, #[serializer(borsh)] _input: Raw) -> AccountId {
+        "erc20.test.near".parse().unwrap()
+    }
+
+    #[result_serializer(borsh)]
+    pub fn get_nep141_from_erc20(&self, #[serializer(borsh)] _input: Raw) -> AccountId {
+        "nep141.test.near".parse().unwrap()
+    }
+
+    #[result_serializer(borsh)]
+    pub fn get_paused_flags(&self, #[serializer(borsh)] _input: Raw) -> u8 {
+        0
+    }
+}

--- a/res/mock_evm/src/out.rs
+++ b/res/mock_evm/src/out.rs
@@ -1,6 +1,6 @@
+use aurora_workspace_types::output::{Log, TransactionStatus};
 use near_sdk::borsh::{self, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
-use aurora_workspace_types::output::{Log, TransactionStatus};
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, Serialize, Deserialize)]
 pub struct SubmitResult {

--- a/workspace/Cargo.toml
+++ b/workspace/Cargo.toml
@@ -7,9 +7,9 @@ readme = "README.md"
 description = "Aurora EVM contract for the Near workspaces library"
 
 [dependencies]
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "745b0cc5f85432a421ba12b699e5e1cc12e3a6bb",  features = ["impl-serde"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "745b0cc5f85432a421ba12b699e5e1cc12e3a6bb" }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "745b0cc5f85432a421ba12b699e5e1cc12e3a6bb",  features = ["impl-serde"] }
+aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "811608b316e1b8f081e78ae03a143b5b3eb35540",  features = ["impl-serde"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "811608b316e1b8f081e78ae03a143b5b3eb35540" }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "811608b316e1b8f081e78ae03a143b5b3eb35540",  features = ["impl-serde"] }
 aurora-workspace-types = { path = "../workspace-types" }
 borsh = { version = "0.9", default-features = false }
 ethabi = { version = "18", optional = true }

--- a/workspace/src/lib.rs
+++ b/workspace/src/lib.rs
@@ -4,7 +4,7 @@ pub(crate) mod operation;
 pub(crate) mod result;
 
 pub use contract::{EvmAccount, EvmContract, InitConfig};
-pub use operation::EvmCallTransaction;
+pub use operation::{EvmCallTransaction, ViewResultDetails};
 
 pub use crate::contract::ContractSource;
 

--- a/workspace/tests/pub_view_tests.rs
+++ b/workspace/tests/pub_view_tests.rs
@@ -1,0 +1,176 @@
+use aurora_engine::parameters::TransactionStatus;
+use aurora_engine_types::U256;
+use aurora_workspace::ViewResultDetails;
+use aurora_workspace_types::{Address, H256};
+
+mod common;
+
+#[tokio::test]
+async fn test_version() -> anyhow::Result<()> {
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract.as_account().version().await?;
+
+    let expected = ViewResultDetails {
+        result: "\"v1\"".to_string(),
+        logs: vec![],
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_view() -> anyhow::Result<()> {
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract
+        .as_account()
+        .view(
+            Address::from([0u8; 20]),
+            Address::from([0u8; 20]),
+            [0; 32],
+            Vec::new(),
+        )
+        .await?;
+
+    let expected = ViewResultDetails {
+        result: TransactionStatus::Succeed(vec![]),
+        logs: vec![],
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eth_total_supply() -> anyhow::Result<()> {
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract.as_account().eth_total_supply().await?;
+
+    let expected = ViewResultDetails {
+        result: U256::default(),
+        logs: vec![],
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}
+
+#[cfg(not(feature = "ethabi"))]
+#[tokio::test]
+async fn test_code() -> anyhow::Result<()> {
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract.as_account().code(Address::from([0u8; 20])).await?;
+
+    let expected = ViewResultDetails {
+        result: hex::decode(b"00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000673706972616c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000067175617361720000000000000000000000000000000000000000000000000000").unwrap(),
+        logs: Default::default(),
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}
+
+#[cfg(feature = "ethabi")]
+#[tokio::test]
+async fn test_code() -> anyhow::Result<()> {
+    use ethabi::{ParamType, Token};
+
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract
+        .as_account()
+        .code(
+            &[ParamType::Tuple(vec![
+                ParamType::String,
+                ParamType::Bool,
+                ParamType::String,
+            ])],
+            Address::from([0u8; 20]),
+        )
+        .await?;
+
+    let expected = ViewResultDetails {
+        result: vec![Token::Tuple(vec![
+            Token::String("spiral".into()),
+            Token::Bool(true),
+            Token::String("quasar".into()),
+        ])],
+        logs: Default::default(),
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_storage() -> anyhow::Result<()> {
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract
+        .as_account()
+        .storage(Address::from([0u8; 20]), [0; 32])
+        .await?;
+
+    let expected = ViewResultDetails {
+        result: H256::from([1; 32]),
+        logs: Default::default(),
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_erc20_from_nep141() -> anyhow::Result<()> {
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract
+        .as_account()
+        .erc20_from_nep141("nep141.test.near".parse().unwrap())
+        .await?;
+
+    let expected = ViewResultDetails {
+        result: "erc20.test.near".parse().unwrap(),
+        logs: Default::default(),
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_nep141_from_erc20() -> anyhow::Result<()> {
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract
+        .as_account()
+        .nep141_from_erc20("erc20.test.near".parse().unwrap())
+        .await?;
+
+    let expected = ViewResultDetails {
+        result: "nep141.test.near".parse().unwrap(),
+        logs: Default::default(),
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_paused_flags() -> anyhow::Result<()> {
+    let contract = common::init_and_deploy_contract().await?;
+
+    let res = contract.as_account().paused_flags().await?;
+
+    let expected = ViewResultDetails {
+        result: 0u8,
+        logs: Default::default(),
+    };
+    assert_eq!(res, expected);
+
+    Ok(())
+}


### PR DESCRIPTION
Adds [`aurora-engine`](https://github.com/aurora-is-near/aurora-engine) contract methods that are missing from the workspace. This PR only deals with the public view methods, others will be added separately.

The methods have already been defined in the [`View` enum here](https://github.com/aurora-is-near/aurora-workspace/blob/main/workspace/src/operation.rs#L279-L302), which currently has variants that are never used in the code.

### Added methods
* eth_total_supply (ft_total_eth_supply_on_aurora)
* get_erc20_from_nep141
* get_nep141_from_erc20
* get_code
* get_storage_at
* get_view
* get_paused_flags

### Note
Please make sure that all the method input/output arguments match those on the engine contract. I tried my best to match them but I'm still lacking some familiarity to be absolutely sure of the changes.

### Other changes
Local mocked test cases for these methods have been added. The existing `ft_transfer` test has been fixed too.

`aurora-engine` and related crates have been updated to latest master because there were multiple versions of a dependency that caused compile errors.