### PR TITLE
feat: add missing self call methods

### DIFF
--- a/res/mock_evm/src/lib.rs
+++ b/res/mock_evm/src/lib.rs
@@ -64,4 +64,26 @@ impl MockEvmContract {
     pub fn register_relayer(&mut self, #[serializer(borsh)] input: Raw) {
         assert_eq!(input.0.len(), 20);
     }
+
+    //
+    // SELF CALL METHODS
+    //
+
+    pub fn set_eth_connector_contract_data(&mut self, #[serializer(borsh)] _input: Raw) {}
+
+    pub fn set_paused_flags(&mut self, #[serializer(borsh)] _input: Raw) {}
+
+    //
+    // CALLBACK HANDLER METHODS
+    //
+
+    #[result_serializer(borsh)]
+    pub fn factory_update_address_version(&mut self, #[serializer(borsh)] _input: Raw) -> u8 {
+        0
+    }
+
+    #[result_serializer(borsh)]
+    pub fn refund_on_error(&mut self, #[serializer(borsh)] _input: Raw) -> u8 {
+        0
+    }
 }

--- a/workspace/src/operation.rs
+++ b/workspace/src/operation.rs
@@ -3,23 +3,25 @@ use crate::error::Error;
 use crate::result::ExecutionSuccess;
 use crate::types::output::SubmitResult;
 use crate::Result;
+use aurora_engine::fungible_token::FungibleTokenMetadata;
 #[cfg(feature = "deposit-withdraw")]
 use aurora_engine::parameters::WithdrawResult;
 use aurora_engine::parameters::{StorageBalance, TransactionStatus};
+#[cfg(feature = "deposit-withdraw")]
+use aurora_engine_sdk::promise::PromiseId;
 use aurora_engine_types::types::Wei;
 use aurora_workspace_types::AccountId;
 use borsh::BorshDeserialize;
 #[cfg(feature = "ethabi")]
 use ethabi::{ParamType, Token};
 use ethereum_types::{Address, H256, U256};
-use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
 use near_sdk::json_types::U128;
 use near_sdk::PromiseOrValue;
 use workspaces::operations::CallTransaction;
 use workspaces::result::ExecutionFinalResult;
 
 macro_rules! impl_call_return  {
-    ($(($name:ident, $return:ty, $fun:ident)),*) => {
+    ($(($name:ident, $return:ty, $deser_fn:ident)),* $(,)?) => {
         $(pub struct $name<'a>(pub(crate) EngineCallTransaction<'a>);
 
         impl<'a> $name<'a> {
@@ -39,7 +41,7 @@ macro_rules! impl_call_return  {
             }
 
             pub async fn transact(self) -> Result<$return> {
-                ExecutionSuccess::$fun(self.0.transact().await?)
+                ExecutionSuccess::$deser_fn(self.0.transact().await?)
             }
         })*
     }
@@ -64,7 +66,19 @@ impl_call_return![
     ),
     (CallStorageDeposit, ExecutionSuccess<()>, try_from),
     (CallStorageUnregister, ExecutionSuccess<()>, try_from),
-    (CallStorageWithdraw, ExecutionSuccess<()>, try_from)
+    (CallStorageWithdraw, ExecutionSuccess<()>, try_from),
+    (
+        CallSetEthConnectorContractData,
+        ExecutionSuccess<()>,
+        try_from_borsh
+    ),
+    (CallSetPausedFlags, ExecutionSuccess<()>, try_from_borsh),
+    (
+        CallFactoryUpdateAddressVersion,
+        ExecutionSuccess<u8>,
+        try_from_borsh
+    ),
+    (CallRefundOnError, ExecutionSuccess<u8>, try_from_borsh),
 ];
 
 #[cfg(feature = "deposit-withdraw")]
@@ -322,10 +336,10 @@ pub enum View {
     EthTotalSupply,
     FtMetadata,
     StorageBalanceOf,
-    PausedFlags,     // TODO
+    PausedFlags,
     AccountsCounter, // TODO
-    Erc20FromNep141, // TODO
-    Nep141FromErc20, // TODO
+    Erc20FromNep141,
+    Nep141FromErc20,
 }
 
 impl AsRef<str> for View {
@@ -401,12 +415,9 @@ impl AsRef<str> for OwnerCall {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SelfCall {
-    NewEthConnector,
     SetEthConnectorContractData,
     FactoryUpdateAddressVersion,
     RefundOnError,
-    FinishDeposit,
-    FtResolveTransfer,
     SetPausedFlags,
 }
 
@@ -414,12 +425,9 @@ impl AsRef<str> for SelfCall {
     fn as_ref(&self) -> &str {
         use SelfCall::*;
         match self {
-            NewEthConnector => "new_eth_connector",
             SetEthConnectorContractData => "set_eth_connector_contract_data",
             FactoryUpdateAddressVersion => "factory_update_address_version",
             RefundOnError => "refund_on_error",
-            FinishDeposit => "finish_deposit",
-            FtResolveTransfer => "resolve_transfer",
             SetPausedFlags => "set_paused_flags",
         }
     }

--- a/workspace/tests/self_call_tests.rs
+++ b/workspace/tests/self_call_tests.rs
@@ -1,0 +1,52 @@
+use aurora_engine::fungible_token::FungibleTokenMetadata;
+use aurora_workspace_types::Address;
+
+mod common;
+
+#[tokio::test]
+async fn test_set_eth_connector_contract_data() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+
+    contract
+        .as_account()
+        .set_eth_connector_contract_data(
+            "prover.test.near",
+            "custodian.test.near",
+            FungibleTokenMetadata::default(),
+        )
+        .transact()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_factory_update_address_version() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+
+    let res = contract
+        .as_account()
+        .factory_update_address_version(Address::default(), 0)
+        .transact()
+        .await
+        .unwrap()
+        .into_value();
+
+    let expected = 0;
+    assert_eq!(expected, res);
+}
+
+#[tokio::test]
+async fn test_refund_on_error() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+
+    let res = contract
+        .as_account()
+        .refund_on_error(Address::default(), Some(Address::default()), 0.into())
+        .transact()
+        .await
+        .unwrap()
+        .into_value();
+
+    let expected = 0;
+    assert_eq!(expected, res);
+}


### PR DESCRIPTION
Adds [`aurora-engine`](https://github.com/aurora-is-near/aurora-engine) contract methods that are missing from the workspace. This PR only deals with the public view methods, others will be added separately.

The methods have already been defined in the [`SelfCall` enum here](https://github.com/aurora-is-near/aurora-workspace/blob/main/workspace/src/operation.rs#L389-L397), which currently has variants that are never used in the code.

### Added methods
* factory_update_address_version
* refund_on_error
* set_eth_connector_contract_data
* set_paused_flags

### Note
The `SelfCall` enum variants related to the eth-connector-specific methods (`new_eth_connector`, `ft_resolve_transfer`, `finish_deposit`) have been removed to reflect the changes in the [NEP-141 split PR](https://github.com/aurora-is-near/aurora-engine/pull/607/files).

Please make sure that all the method input/output arguments match those on the engine contract. I tried my best to match them but I'm still lacking some familiarity to be absolutely sure of the changes.

### Other changes
Local mocked test cases for these methods have been added. The existing `ft_resolve_transfer` mock-evm stub method has been fixed too.