### PR TITLE
feat: add missing owner call methods

### DIFF
--- a/res/mock_evm/Cargo.lock
+++ b/res/mock_evm/Cargo.lock
@@ -58,10 +58,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-engine-types"
+version = "1.0.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=811608b316e1b8f081e78ae03a143b5b3eb35540#811608b316e1b8f081e78ae03a143b5b3eb35540"
+dependencies = [
+ "borsh",
+ "hex",
+ "primitive-types 0.12.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "aurora-workspace-types"
 version = "0.1.0"
 dependencies = [
- "aurora-engine-types",
+ "aurora-engine-types 1.0.0 (git+https://github.com/aurora-is-near/aurora-engine.git?rev=745b0cc5f85432a421ba12b699e5e1cc12e3a6bb)",
  "ethereum-types",
  "near-account-id 0.15.0",
  "near-sdk",
@@ -502,6 +514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -740,6 +753,7 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 name = "mock_evm"
 version = "0.1.0"
 dependencies = [
+ "aurora-engine-types 1.0.0 (git+https://github.com/aurora-is-near/aurora-engine.git?rev=811608b316e1b8f081e78ae03a143b5b3eb35540)",
  "aurora-workspace-types",
  "getrandom 0.2.8",
  "hex",
@@ -1117,6 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash 0.8.0",
+ "impl-codec 0.6.0",
  "impl-rlp",
  "impl-serde 0.4.0",
  "uint",

--- a/res/mock_evm/Cargo.toml
+++ b/res/mock_evm/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aurora-workspace-types = { path = "../../workspace-types" }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "811608b316e1b8f081e78ae03a143b5b3eb35540",  features = ["impl-serde"] }
 hex = "0.4.3"
 near-sdk = "4.1"
 near-contract-standards = "4.1"

--- a/res/mock_evm/src/lib.rs
+++ b/res/mock_evm/src/lib.rs
@@ -66,12 +66,38 @@ impl MockEvmContract {
     }
 
     //
+    // OWNER CALL METHODS
+    //
+
+    #[allow(unused_variables)]
+    pub fn factory_update(&mut self, #[serializer(borsh)] bytes: Raw) {}
+
+    #[allow(unused_variables)]
+    pub fn factory_set_wnear_address(
+        &mut self,
+        #[serializer(borsh)] input: aurora_engine_types::types::Address,
+    ) {
+    }
+
+    #[allow(unused_variables)]
+    pub fn deploy_upgrade(&mut self) {}
+
+    #[allow(unused_variables)]
+    pub fn resume_precompiles(&mut self, #[serializer(borsh)] paused_mask: u32) {}
+
+    #[allow(unused_variables)]
+    pub fn stage_upgrade(&mut self, #[serializer(borsh)] input: Raw) {}
+
+    pub fn state_migration(&mut self) {}
+
+    //
     // SELF CALL METHODS
     //
 
     pub fn set_eth_connector_contract_data(&mut self, #[serializer(borsh)] _input: Raw) {}
 
-    pub fn set_paused_flags(&mut self, #[serializer(borsh)] _input: Raw) {}
+    #[allow(unused_variables)]
+    pub fn set_paused_flags(&mut self, #[serializer(borsh)] paused_mask: u32) {}
 
     //
     // CALLBACK HANDLER METHODS

--- a/res/mock_evm/src/lib.rs
+++ b/res/mock_evm/src/lib.rs
@@ -64,4 +64,26 @@ impl MockEvmContract {
     pub fn register_relayer(&mut self, #[serializer(borsh)] input: Raw) {
         assert_eq!(input.0.len(), 20);
     }
+
+    //
+    // SELF CALL METHODS
+    //
+
+    pub fn set_eth_connector_contract_data(&mut self, #[serializer(borsh)] _input: Raw) {}
+
+    pub fn set_paused_flags(&mut self, #[serializer(borsh)] _input: Raw) {}
+
+    //
+    // CALLBACK HANDLER METHODS
+    //
+
+    #[result_serializer(borsh)]
+    pub fn factory_update_address_version(&mut self, #[serializer(borsh)] _input: Raw) -> u8 {
+        0
+    }
+
+    #[result_serializer(borsh)]
+    pub fn refund_on_error(&mut self, #[serializer(borsh)] _input: Raw) -> u8 {
+        0
+    }
 }

--- a/workspace/src/operation.rs
+++ b/workspace/src/operation.rs
@@ -79,6 +79,12 @@ impl_call_return![
         try_from_borsh
     ),
     (CallRefundOnError, ExecutionSuccess<u8>, try_from_borsh),
+    (CallFactoryUpdate, ExecutionSuccess<()>, try_from),
+    (CallFactorySetWNearAddress, ExecutionSuccess<()>, try_from),
+    (CallDeployUpgrade, ExecutionSuccess<()>, try_from),
+    (CallResumePrecompiles, ExecutionSuccess<()>, try_from),
+    (CallStageUpgrade, ExecutionSuccess<()>, try_from),
+    (CallStateMigration, ExecutionSuccess<()>, try_from),
 ];
 
 #[cfg(feature = "deposit-withdraw")]

--- a/workspace/src/operation.rs
+++ b/workspace/src/operation.rs
@@ -3,23 +3,25 @@ use crate::error::Error;
 use crate::result::ExecutionSuccess;
 use crate::types::output::SubmitResult;
 use crate::Result;
+use aurora_engine::fungible_token::FungibleTokenMetadata;
 #[cfg(feature = "deposit-withdraw")]
 use aurora_engine::parameters::WithdrawResult;
 use aurora_engine::parameters::{StorageBalance, TransactionStatus};
+#[cfg(feature = "deposit-withdraw")]
+use aurora_engine_sdk::promise::PromiseId;
 use aurora_engine_types::types::Wei;
 use aurora_workspace_types::AccountId;
 use borsh::BorshDeserialize;
 #[cfg(feature = "ethabi")]
 use ethabi::{ParamType, Token};
 use ethereum_types::{Address, H256, U256};
-use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
 use near_sdk::json_types::U128;
 use near_sdk::PromiseOrValue;
 use workspaces::operations::CallTransaction;
 use workspaces::result::ExecutionFinalResult;
 
 macro_rules! impl_call_return  {
-    ($(($name:ident, $return:ty, $fun:ident)),*) => {
+    ($(($name:ident, $return:ty, $deser_fn:ident)),* $(,)?) => {
         $(pub struct $name<'a>(pub(crate) EngineCallTransaction<'a>);
 
         impl<'a> $name<'a> {
@@ -39,7 +41,7 @@ macro_rules! impl_call_return  {
             }
 
             pub async fn transact(self) -> Result<$return> {
-                ExecutionSuccess::$fun(self.0.transact().await?)
+                ExecutionSuccess::$deser_fn(self.0.transact().await?)
             }
         })*
     }
@@ -64,7 +66,19 @@ impl_call_return![
     ),
     (CallStorageDeposit, ExecutionSuccess<()>, try_from),
     (CallStorageUnregister, ExecutionSuccess<()>, try_from),
-    (CallStorageWithdraw, ExecutionSuccess<()>, try_from)
+    (CallStorageWithdraw, ExecutionSuccess<()>, try_from),
+    (
+        CallSetEthConnectorContractData,
+        ExecutionSuccess<()>,
+        try_from_borsh
+    ),
+    (CallSetPausedFlags, ExecutionSuccess<()>, try_from_borsh),
+    (
+        CallFactoryUpdateAddressVersion,
+        ExecutionSuccess<u8>,
+        try_from_borsh
+    ),
+    (CallRefundOnError, ExecutionSuccess<u8>, try_from_borsh),
 ];
 
 #[cfg(feature = "deposit-withdraw")]
@@ -322,10 +336,10 @@ pub enum View {
     EthTotalSupply,
     FtMetadata,
     StorageBalanceOf,
-    PausedFlags,     // TODO
+    PausedFlags,
     AccountsCounter, // TODO
-    Erc20FromNep141, // TODO
-    Nep141FromErc20, // TODO
+    Erc20FromNep141,
+    Nep141FromErc20,
 }
 
 impl AsRef<str> for View {
@@ -401,12 +415,9 @@ impl AsRef<str> for OwnerCall {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SelfCall {
-    NewEthConnector,
     SetEthConnectorContractData,
     FactoryUpdateAddressVersion,
     RefundOnError,
-    FinishDeposit,
-    FtResolveTransfer,
     SetPausedFlags,
 }
 
@@ -414,12 +425,9 @@ impl AsRef<str> for SelfCall {
     fn as_ref(&self) -> &str {
         use SelfCall::*;
         match self {
-            NewEthConnector => "new_eth_connector",
             SetEthConnectorContractData => "set_eth_connector_contract_data",
             FactoryUpdateAddressVersion => "factory_update_address_version",
             RefundOnError => "refund_on_error",
-            FinishDeposit => "finish_deposit",
-            FtResolveTransfer => "resolve_transfer",
             SetPausedFlags => "set_paused_flags",
         }
     }

--- a/workspace/tests/owner_call_tests.rs
+++ b/workspace/tests/owner_call_tests.rs
@@ -1,0 +1,67 @@
+mod common;
+
+#[tokio::test]
+async fn test_factory_update() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+    contract
+        .as_account()
+        .factory_update(vec![0u8; 100])
+        .transact()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_factory_set_wnear_address() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+    contract
+        .as_account()
+        .factory_set_wnear_address([0; 20])
+        .transact()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_stage_upgrade() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+    contract
+        .as_account()
+        .stage_upgrade(vec![0u8; 100])
+        .transact()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_deploy_upgrade() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+    contract
+        .as_account()
+        .deploy_upgrade()
+        .transact()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_state_migration() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+    contract
+        .as_account()
+        .state_migration()
+        .transact()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_resume_precompiles() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+    contract
+        .as_account()
+        .resume_precompiles(0)
+        .transact()
+        .await
+        .unwrap();
+}

--- a/workspace/tests/self_call_tests.rs
+++ b/workspace/tests/self_call_tests.rs
@@ -1,0 +1,52 @@
+use aurora_engine::fungible_token::FungibleTokenMetadata;
+use aurora_workspace_types::Address;
+
+mod common;
+
+#[tokio::test]
+async fn test_set_eth_connector_contract_data() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+
+    contract
+        .as_account()
+        .set_eth_connector_contract_data(
+            "prover.test.near",
+            "custodian.test.near",
+            FungibleTokenMetadata::default(),
+        )
+        .transact()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_factory_update_address_version() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+
+    let res = contract
+        .as_account()
+        .factory_update_address_version(Address::default(), 0)
+        .transact()
+        .await
+        .unwrap()
+        .into_value();
+
+    let expected = 0;
+    assert_eq!(expected, res);
+}
+
+#[tokio::test]
+async fn test_refund_on_error() {
+    let contract = common::init_and_deploy_contract().await.unwrap();
+
+    let res = contract
+        .as_account()
+        .refund_on_error(Address::default(), Some(Address::default()), 0.into())
+        .transact()
+        .await
+        .unwrap()
+        .into_value();
+
+    let expected = 0;
+    assert_eq!(expected, res);
+}


### PR DESCRIPTION
Adds [`aurora-engine`](https://github.com/aurora-is-near/aurora-engine) contract methods that are missing from the workspace. This PR only deals with the public view methods, others will be added separately.

The methods have already been defined in the [`OwnerCall` enum here](https://github.com/aurora-is-near/aurora-workspace/blob/main/workspace/src/operation.rs#L389-L397), which currently has variants that are never used in the code.

### Added methods
* factory_update
* factory_set_wnear_address
* deploy_upgrade
* resume_precompiles
* stage_upgrade
* state_migration

### Note
Please make sure that all the method input/output arguments match those on the engine contract. I tried my best to match them but I'm still lacking some familiarity to be absolutely sure of the changes.

### Other changes
Local mocked test cases for these methods have been added.