### PR TITLE
Feat: remove `statistics_aurora_accounts_counter`

### DIFF
--- a/res/mock_eth_connector/src/migration.rs
+++ b/res/mock_eth_connector/src/migration.rs
@@ -7,7 +7,6 @@ pub struct MigrationInputData {
     pub accounts: HashMap<AccountId, Balance>,
     pub total_supply: Option<Balance>,
     pub account_storage_usage: Option<StorageUsage>,
-    pub statistics_aurora_accounts_counter: Option<u64>,
     pub used_proofs: Vec<String>,
 }
 

--- a/workspace-eth-connector/src/types.rs
+++ b/workspace-eth-connector/src/types.rs
@@ -9,7 +9,6 @@ pub struct MigrationInputData {
     pub accounts: HashMap<AccountId, Balance>,
     pub total_supply: Option<Balance>,
     pub account_storage_usage: Option<StorageUsage>,
-    pub statistics_aurora_accounts_counter: Option<u64>,
     pub used_proofs: Vec<String>,
 }
 


### PR DESCRIPTION
# Description

After removing `accounts_counter` field from `aurora-eth-connector` we should remove `statistics_aurora_accounts_counter`.