### PR TITLE
chore: bump rust and dependencies versions 

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -40,6 +40,6 @@ jobs:
           cache-util save cargo_git cargo_registry
 
 env:
-  RUST_VERSION: 1.81.0
+  RUST_VERSION: 1.83.0
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -40,6 +40,6 @@ jobs:
           cache-util save cargo_git cargo_registry
 
 env:
-  RUST_VERSION: 1.74.1
+  RUST_VERSION: 1.80.0
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -40,6 +40,6 @@ jobs:
           cache-util save cargo_git cargo_registry
 
 env:
-  RUST_VERSION: 1.80.0
+  RUST_VERSION: 1.81.0
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           rustup show
           rustup default ${{ env.RUST_VERSION }}
+          rustup target add wasm32-unknown-unknown
       - name: Clone the repository
         uses: actions/checkout@v4
       - name: Restore cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ version = "0.4.1"
 [workspace.dependencies]
 anyhow = "1"
 aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["impl-serde"] }
-near-contract-standards = "5.11"
+near-contract-standards = "5.2"
 near-sdk = "5.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-workspaces = "0.18"
+near-workspaces = "0.12"
 borsh = "^1"
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ version = "0.4.1"
 anyhow = "1"
 aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["impl-serde"] }
 near-contract-standards = "5.2"
-near-sdk = "5.2"
+near-sdk = { version = "5.11", features = ["unit-testing"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 near-workspaces = "0.12"
 borsh = "^1"
-cargo-near-build = "0.4.4"
+cargo-near-build = "0.4.5"
 
 [patch.crates-io]
 parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.4.1"
 anyhow = "1"
 aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["impl-serde"] }
 near-contract-standards = "5.2"
-near-sdk = "5.11"
+near-sdk = "5.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 near-workspaces = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 near-workspaces = "0.12"
 borsh = "^1"
+cargo-near-build = "0.4.4"
 
 [patch.crates-io]
 parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,13 @@ version = "0.4.1"
 
 [workspace.dependencies]
 anyhow = "1"
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.5.0", default-features = false, features = ["impl-serde"] }
-near-contract-standards = "4.1"
-near-sdk = "4.1"
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["impl-serde"] }
+near-contract-standards = "5.11"
+near-sdk = "5.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-near-workspaces = "0.9"
+near-workspaces = "0.18"
+borsh = "^1"
 
 [patch.crates-io]
 parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,12 @@ check-fmt:
 fmt:
 	@cargo fmt --all
 
+build-mock-engine:
+	@cd ${ENGINE_MOCK_DIR} && ${MOCK_CARGO_BUILD}
+
+build-mock-eth-connector:
+	@cd ${ETH_CONNECTOR_MOCK_DIR} && ${MOCK_CARGO_BUILD}
+
 test-engine:
 	@cargo test --package aurora-workspace-engine -- --test-threads 10 --nocapture
 

--- a/Makefile
+++ b/Makefile
@@ -41,19 +41,6 @@ check-fmt:
 fmt:
 	@cargo fmt --all
 
-build-mock-engine:
-	@cd ${ENGINE_MOCK_DIR} && ${MOCK_CARGO_BUILD}
-
-build-mock-eth-connector:
-	@cd ${ETH_CONNECTOR_MOCK_DIR} && ${MOCK_CARGO_BUILD}
-
-create-bin-dir:
-	@mkdir -p bin || true
-
-cp-built-mocks: create-bin-dir
-	@cp -rf ${ENGINE_MOCK_FILE} bin/
-	@cp -rf ${ETH_CONNECTOR_MOCK_FILE} bin/
-
 test-engine:
 	@cargo test --package aurora-workspace-engine -- --test-threads 10 --nocapture
 
@@ -68,4 +55,4 @@ clean: clean_engine_mock clean_eth_connector_mock clean_workspace
 
 test-flow: test-engine test-eth-connector
 
-test: build-mock-engine build-mock-eth-connector cp-built-mocks test-flow
+test: test-flow

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -15,6 +15,7 @@ near-sdk.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 near-workspaces.workspace = true
+borsh.workspace = true
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/engine/src/contract.rs
+++ b/engine/src/contract.rs
@@ -13,7 +13,7 @@ use crate::operation::{
 };
 use crate::types::Account;
 use aurora_engine_types::account_id::AccountId;
-use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
 use aurora_engine_types::parameters::connector::{FungibleTokenMetadata, Proof};
 use aurora_engine_types::parameters::engine::{
     CallArgs, FunctionCallArgsV2, NewCallArgs, NewCallArgsV2,
@@ -21,8 +21,6 @@ use aurora_engine_types::parameters::engine::{
 use aurora_engine_types::types::{Address, RawU256, WeiU256};
 use aurora_engine_types::{H256, U256};
 use aurora_workspace_utils::{Contract, ContractId};
-#[cfg(feature = "ethabi")]
-use ethabi::{ParamType, Token};
 use near_sdk::json_types::U128;
 use serde_json::json;
 
@@ -183,7 +181,7 @@ impl EngineContract {
     }
 
     pub fn call(&self, contract: Address, amount: U256, input: Vec<u8>) -> CallCall {
-        let value = WeiU256::from(amount);
+        let value = WeiU256::from(amount.to_big_endian());
         let args = CallArgs::V2(FunctionCallArgsV2 {
             contract,
             value,
@@ -337,9 +335,7 @@ impl EngineContract {
         amount: U256,
         input: Vec<u8>,
     ) -> ViewView {
-        let mut raw_amount = [0u8; 32];
-        amount.to_big_endian(&mut raw_amount);
-        ViewView::view(&self.contract).args_borsh((sender, address, raw_amount, input))
+        ViewView::view(&self.contract).args_borsh((sender, address, amount.to_big_endian(), input))
     }
 
     pub fn is_used_proof(&self, proof: Proof) -> ViewIsUsedProof {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -160,8 +160,5 @@ impl EngineContractBuilder {
 
 fn into_chain_id(value: u64) -> [u8; 32] {
     let chain_id = U256::from(value);
-    let mut result = [0; 32];
-    chain_id.to_big_endian(&mut result);
-
-    result
+    chain_id.to_big_endian()
 }

--- a/engine/tests/utils.rs
+++ b/engine/tests/utils.rs
@@ -4,8 +4,8 @@ use ethereum_types::U256;
 use near_workspaces::types::{KeyType, SecretKey};
 
 const AURORA_LOCAL_CHAIN_ID: u64 = 1313161556;
-const AURORA_ACCOUNT_ID: &str = "aurora.near";
-const OWNER_ACCOUNT_ID: &str = "owner.near";
+const AURORA_ACCOUNT_ID: &str = "aurora";
+const OWNER_ACCOUNT_ID: &str = "owner";
 const WASM_BIN_FILE_PATH: &str = "../bin/mock_engine.wasm";
 
 pub async fn deploy_and_init_contract() -> anyhow::Result<EngineContract> {

--- a/engine/tests/utils.rs
+++ b/engine/tests/utils.rs
@@ -1,12 +1,11 @@
 use aurora_workspace_engine::EngineContract;
-use aurora_workspace_utils::Contract;
+use aurora_workspace_utils::{compile::compile_project, Contract};
 use ethereum_types::U256;
 use near_workspaces::types::{KeyType, SecretKey};
 
 const AURORA_LOCAL_CHAIN_ID: u64 = 1313161556;
 const AURORA_ACCOUNT_ID: &str = "aurora";
 const OWNER_ACCOUNT_ID: &str = "owner";
-const WASM_BIN_FILE_PATH: &str = "../bin/mock_engine.wasm";
 
 pub async fn deploy_and_init_contract() -> anyhow::Result<EngineContract> {
     let worker = near_workspaces::sandbox()
@@ -17,8 +16,9 @@ pub async fn deploy_and_init_contract() -> anyhow::Result<EngineContract> {
         .create_tla(AURORA_ACCOUNT_ID.parse()?, sk)
         .await?
         .into_result()?;
-    let wasm = std::fs::read(WASM_BIN_FILE_PATH)
-        .map_err(|e| anyhow::anyhow!("failed read wasm file: {e}"))?;
+    let wasm_path = compile_project("../res/mock_engine").await;
+    let wasm =
+        std::fs::read(wasm_path).map_err(|e| anyhow::anyhow!("failed read wasm file: {e}"))?;
     // create contract
     let contract = Contract::deploy(&evm_account, wasm).await?;
     let engine_contract = EngineContract::new_from_contract(contract, evm_account);

--- a/engine/tests/utils.rs
+++ b/engine/tests/utils.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use aurora_workspace_engine::EngineContract;
 use aurora_workspace_utils::{compile::compile_project, Contract};
 use ethereum_types::U256;
@@ -6,6 +8,13 @@ use near_workspaces::types::{KeyType, SecretKey};
 const AURORA_LOCAL_CHAIN_ID: u64 = 1313161556;
 const AURORA_ACCOUNT_ID: &str = "aurora";
 const OWNER_ACCOUNT_ID: &str = "owner";
+
+pub static CONTRACT_WASM: LazyLock<Vec<u8>> = LazyLock::new(|| {
+    let wasm_path = compile_project("../res/mock_engine");
+    std::fs::read(wasm_path)
+        .map_err(|e| anyhow::anyhow!("failed read wasm file: {e}"))
+        .unwrap()
+});
 
 pub async fn deploy_and_init_contract() -> anyhow::Result<EngineContract> {
     let worker = near_workspaces::sandbox()
@@ -16,11 +25,9 @@ pub async fn deploy_and_init_contract() -> anyhow::Result<EngineContract> {
         .create_tla(AURORA_ACCOUNT_ID.parse()?, sk)
         .await?
         .into_result()?;
-    let wasm_path = compile_project("../res/mock_engine").await;
-    let wasm =
-        std::fs::read(wasm_path).map_err(|e| anyhow::anyhow!("failed read wasm file: {e}"))?;
+
     // create contract
-    let contract = Contract::deploy(&evm_account, wasm).await?;
+    let contract = Contract::deploy(&evm_account, CONTRACT_WASM.to_owned()).await?;
     let engine_contract = EngineContract::new_from_contract(contract, evm_account);
 
     engine_contract

--- a/engine/tests/utils.rs
+++ b/engine/tests/utils.rs
@@ -4,8 +4,8 @@ use ethereum_types::U256;
 use near_workspaces::types::{KeyType, SecretKey};
 
 const AURORA_LOCAL_CHAIN_ID: u64 = 1313161556;
-const AURORA_ACCOUNT_ID: &str = "aurora.test.near";
-const OWNER_ACCOUNT_ID: &str = "owner.test.near";
+const AURORA_ACCOUNT_ID: &str = "aurora.near";
+const OWNER_ACCOUNT_ID: &str = "owner.near";
 const WASM_BIN_FILE_PATH: &str = "../bin/mock_engine.wasm";
 
 pub async fn deploy_and_init_contract() -> anyhow::Result<EngineContract> {

--- a/eth-connector/Cargo.toml
+++ b/eth-connector/Cargo.toml
@@ -15,6 +15,7 @@ near-sdk.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 near-workspaces.workspace = true
+borsh.workspace = true
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/eth-connector/src/contract.rs
+++ b/eth-connector/src/contract.rs
@@ -14,8 +14,9 @@ use aurora_engine_types::types::Address;
 use aurora_workspace_utils::{Contract, ContractId};
 use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
 use near_sdk::json_types::U128;
-use near_sdk::Balance;
 use serde_json::json;
+
+type Balance = u128;
 
 #[derive(Debug, Clone)]
 pub struct EthConnectorContract {

--- a/eth-connector/src/operation.rs
+++ b/eth-connector/src/operation.rs
@@ -54,6 +54,7 @@ impl_view_return![
     (ViewGetAuroraEngineAccountId => AccountId, View::GetAuroraEngineAccountId, json)
 ];
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum Call {
     New,

--- a/eth-connector/src/types.rs
+++ b/eth-connector/src/types.rs
@@ -1,9 +1,11 @@
-use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
 use aurora_engine_types::types::Address;
-use near_sdk::{Balance, StorageUsage};
+use near_sdk::StorageUsage;
 use near_workspaces::AccountId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+type Balance = u128;
 
 #[derive(Default, BorshDeserialize, BorshSerialize)]
 pub struct MigrationInputData {

--- a/eth-connector/tests/fungible_token_tests.rs
+++ b/eth-connector/tests/fungible_token_tests.rs
@@ -2,6 +2,7 @@ use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::types::Address;
 use aurora_workspace_eth_connector::contract::EthConnectorContract;
 use aurora_workspace_eth_connector::types::{MigrationCheckResult, MigrationInputData, Proof};
+use aurora_workspace_utils::compile::compile_project;
 use aurora_workspace_utils::results::ViewResult;
 use aurora_workspace_utils::ContractId;
 use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, FT_METADATA_SPEC};
@@ -13,11 +14,11 @@ use std::str::FromStr;
 pub const CUSTODIAN_ADDRESS: &str = "096DE9C2B8A5B8c22cEe3289B101f6960d68E51E";
 pub const OWNER_ID: &str = "aurora.test.near";
 pub const PROVER_ID: &str = "prover.test.near";
-const WASM_BIN_FILE_PATH: &str = "../bin/mock_eth_connector.wasm";
 
 async fn deploy_and_init() -> anyhow::Result<EthConnectorContract> {
+    let wasm_path = compile_project("../res/mock_eth_connector").await;
     let (eth_contract, account) =
-        aurora_workspace_eth_connector::deploy(WASM_BIN_FILE_PATH).await?;
+        aurora_workspace_eth_connector::deploy(wasm_path.as_path()).await?;
     let prover_account = AccountId::from_str(PROVER_ID).unwrap();
     let eth_custodian_address = CUSTODIAN_ADDRESS.to_string();
     let metadata = FungibleTokenMetadata {

--- a/eth-connector/tests/fungible_token_tests.rs
+++ b/eth-connector/tests/fungible_token_tests.rs
@@ -9,16 +9,20 @@ use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, F
 use near_sdk::json_types::U128;
 use near_sdk::PromiseOrValue;
 use near_workspaces::types::NearToken;
+use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 pub const CUSTODIAN_ADDRESS: &str = "096DE9C2B8A5B8c22cEe3289B101f6960d68E51E";
 pub const OWNER_ID: &str = "aurora.test.near";
 pub const PROVER_ID: &str = "prover.test.near";
 
+pub static CONTRACT_PATH: LazyLock<PathBuf> =
+    LazyLock::new(|| compile_project("../res/mock_eth_connector"));
+
 async fn deploy_and_init() -> anyhow::Result<EthConnectorContract> {
-    let wasm_path = compile_project("../res/mock_eth_connector").await;
     let (eth_contract, account) =
-        aurora_workspace_eth_connector::deploy(wasm_path.as_path()).await?;
+        aurora_workspace_eth_connector::deploy(CONTRACT_PATH.as_path()).await?;
     let prover_account = AccountId::from_str(PROVER_ID).unwrap();
     let eth_custodian_address = CUSTODIAN_ADDRESS.to_string();
     let metadata = FungibleTokenMetadata {

--- a/eth-connector/tests/fungible_token_tests.rs
+++ b/eth-connector/tests/fungible_token_tests.rs
@@ -164,8 +164,8 @@ async fn test_storage_deposit() {
         .await
         .unwrap()
         .into_value();
-    assert_eq!(res.total, U128::from(100));
-    assert_eq!(res.available, U128::from(200));
+    assert_eq!(res.total, NearToken::from_yoctonear(100));
+    assert_eq!(res.available, NearToken::from_yoctonear(200));
 }
 
 #[tokio::test]
@@ -179,8 +179,8 @@ async fn test_storage_withdraw() {
         .await
         .unwrap()
         .into_value();
-    assert_eq!(res.total, U128::from(100));
-    assert_eq!(res.available, U128::from(200));
+    assert_eq!(res.total, NearToken::from_yoctonear(100));
+    assert_eq!(res.available, NearToken::from_yoctonear(200));
 }
 
 #[tokio::test]
@@ -209,8 +209,8 @@ async fn test_engine_storage_deposit() {
         .await
         .unwrap()
         .into_value();
-    assert_eq!(res.total, U128::from(100));
-    assert_eq!(res.available, U128::from(200));
+    assert_eq!(res.total, NearToken::from_yoctonear(100));
+    assert_eq!(res.available, NearToken::from_yoctonear(200));
 }
 
 #[tokio::test]
@@ -225,8 +225,8 @@ async fn test_engine_storage_withdraw() {
         .await
         .unwrap()
         .into_value();
-    assert_eq!(res.total, U128::from(100));
-    assert_eq!(res.available, U128::from(200));
+    assert_eq!(res.total, NearToken::from_yoctonear(100));
+    assert_eq!(res.available, NearToken::from_yoctonear(200));
 }
 
 #[tokio::test]
@@ -250,16 +250,16 @@ async fn test_storage_balance_of() {
     let account_id = AccountId::from_str("test.near").unwrap();
     let res = contract.storage_balance_of(&account_id).await.unwrap();
     let result = res.result;
-    assert_eq!(result.total, U128::from(10));
-    assert_eq!(result.available, U128::from(20));
+    assert_eq!(result.total, NearToken::from_yoctonear(10));
+    assert_eq!(result.available, NearToken::from_yoctonear(20));
 }
 
 #[tokio::test]
 async fn test_storage_balance_bounds() {
     let contract = deploy_and_init().await.unwrap();
     let res = contract.storage_balance_bounds().await.unwrap();
-    assert_eq!(res.result.min, U128::from(100));
-    assert_eq!(res.result.max, Some(U128::from(200)));
+    assert_eq!(res.result.min, NearToken::from_yoctonear(100));
+    assert_eq!(res.result.max, Some(NearToken::from_yoctonear(200)));
 }
 
 #[tokio::test]

--- a/res/mock_eth_connector/src/connector.rs
+++ b/res/mock_eth_connector/src/connector.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::Proof;
 use aurora_engine_types::types::Address;
 use near_contract_standards::storage_management::StorageBalance;

--- a/res/mock_eth_connector/src/migration.rs
+++ b/res/mock_eth_connector/src/migration.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::{ext_contract, AccountId, Balance, StorageUsage};
 use std::collections::HashMap;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -12,3 +12,4 @@ near-sdk.workspace = true
 serde.workspace = true
 tokio = "1"
 near-workspaces.workspace = true
+cargo-near-build.workspace = true

--- a/utils/src/compile.rs
+++ b/utils/src/compile.rs
@@ -1,0 +1,17 @@
+use std::{path::PathBuf, str::FromStr};
+
+pub async fn compile_project(project_path: &str) -> PathBuf {
+    let path = std::path::Path::new(project_path).join("Cargo.toml");
+    let artifact = cargo_near_build::build(cargo_near_build::BuildOpts {
+        manifest_path: Some(
+            cargo_near_build::camino::Utf8PathBuf::from_str(path.to_str().unwrap())
+                .expect("camino PathBuf from str"),
+        ),
+        no_abi: true,
+        no_locked: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    artifact.path.into_std_path_buf()
+}

--- a/utils/src/compile.rs
+++ b/utils/src/compile.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, str::FromStr};
 
-pub async fn compile_project(project_path: &str) -> PathBuf {
+pub fn compile_project(project_path: &str) -> PathBuf {
     let path = std::path::Path::new(project_path).join("Cargo.toml");
     let artifact = cargo_near_build::build(cargo_near_build::BuildOpts {
         manifest_path: Some(

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -6,6 +6,7 @@ use near_workspaces::{Account, AccountId, Worker};
 pub mod macros;
 pub mod results;
 pub mod transactions;
+pub mod compile;
 
 pub trait ContractId {
     fn as_contract(&self) -> &Contract;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -73,7 +73,7 @@ impl Contract {
         self.account.call(function)
     }
 
-    pub fn near_view<'a, F: AsRef<str>>(&'a self, function_name: &'a F) -> ViewTransaction {
+    pub fn near_view<F: AsRef<str>>(&self, function_name: &F) -> ViewTransaction {
         self.account.view(function_name)
     }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -3,10 +3,10 @@ use near_workspaces::network::NetworkClient;
 use near_workspaces::types::{KeyType, NearToken, SecretKey};
 use near_workspaces::{Account, AccountId, Worker};
 
+pub mod compile;
 pub mod macros;
 pub mod results;
 pub mod transactions;
-pub mod compile;
 
 pub trait ContractId {
     fn as_contract(&self) -> &Contract;

--- a/utils/src/results.rs
+++ b/utils/src/results.rs
@@ -46,7 +46,7 @@ impl ViewResult<U256> {
         let mut buf = [0u8; 32];
         buf.copy_from_slice(view.result.as_slice());
         Ok(Self {
-            result: U256::from(buf),
+            result: U256::from_big_endian(&buf),
             logs: view.logs,
         })
     }


### PR DESCRIPTION
This should fix the CI error:
```
error: package `home v0.5.11` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.74.1
Either upgrade to rustc 1.81 or newer, or use
cargo update home@0.5.11 --precise ver
where `ver` is the latest version of `home` supporting rustc 1.74.1
make: *** [Makefile:31: clippy-lib] Error 101
```

and 

```
error: rustc 1.80.0 is not supported by the following packages:
  base64ct@1.7.3 requires rustc 1.81
  base64ct@1.7.3 requires rustc 1.81
  home@0.5.11 requires rustc 1.81
  home@0.5.11 requires rustc 1.81
  litemap@0.7.5 requires rustc 1.81
  litemap@0.7.5 requires rustc 1.81
  zerofrom@0.1.6 requires rustc 1.81
  zerofrom@0.1.6 requires rustc 1.81
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.80.0
```